### PR TITLE
Fix: Ampersand operator in any position in selector issue in plugins

### DIFF
--- a/lib/api/add.js
+++ b/lib/api/add.js
@@ -27,7 +27,7 @@ module.exports = function(API) {
 		}
 		// ampersand 
 		for(var prop in props) {
-			if(prop.charAt(0) === "&") {
+			if(/&/g.test(prop)) {
 				props[prop] = false;
 			}
 		}

--- a/tests/bugs/ampersand.and.plugin.spec.js
+++ b/tests/bugs/ampersand.and.plugin.spec.js
@@ -11,6 +11,9 @@ describe("Fixing bug with ampersand inside a plugin", function() {
 		            ".ie8 &": {
 		            	color: "blue"
 		            }
+		        },
+		        ".ie8 &": {
+		            color: "#eee"
 		        }
 		    };
 		});
@@ -32,6 +35,9 @@ a:hover {\n\
 }\n\
 .ie8 a:hover {\n\
   color: blue;\n\
+}\n\
+.ie8 a {\n\
+  color: #eee;\n\
 }\n");
 			done();
 		});		


### PR DESCRIPTION
changed ampersand operator clearing condition with regex test

```
api.plugin("hoverEffect", function(api, color) {
    return {
        "&:hover": {
            color: color,
            background: api.lighten(color, 60),
            ".ie8 &": {
                color: "blue"
            }
        },
        ".ie8 &": {
            color: "#eee"
        }
    };
});
api.add({
    a: {
        color: "#000",
        hoverEffect: "#999"
    }
});
```

result

```
a {
  color: #000;
}
a:hover {
  color: #999;
  background: #f5f5f5;
}
.ie8 a:hover {
  color: blue;
}
.ie8 a {
  color: #eee;
}
```

maybe this could be useful for those who arrange nested selector hierarchy differently

about usage of ampersand operator in yaml. the selector needs to be enclosed in quotes/double quotes to work.

```

---
a:
  '.ie6 &':
...
```
