### PR TITLE
Made compile() return the processed data

### DIFF
--- a/lib/api/compile.js
+++ b/lib/api/compile.js
@@ -20,7 +20,7 @@ module.exports = function(api) {
 		};
 		options = extend(_defaultOptions, options || {});
 
-		options.processor(
+		return options.processor(
 			api.getRules(),
 			function(err, result) {
 				if(path != null) {


### PR DESCRIPTION
Made it return the processed data that the processor returns. In case of not being able to use the result meanfully in the callback but instead needs to return the result for it to be used.
