### PR TITLE
Add browser property to make absurd work well with bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": "http://absurdjs.com/",
   "description": "JavaScript library with superpowers - http://absurdjs.com/",
   "main": "./index.js",
+  "browser": "./client-side/build/absurd.min.js",
   "author": {
     "name": "Krasimir Tsonev",
     "email": "info@krasimirtsonev.com",


### PR DESCRIPTION
Adding the `browser` field so that bundlers like webpack will automatically pick up the client-side version of absurd.

More on `browser` here:
https://gist.github.com/defunctzombie/4339901