### PR TITLE
Replacing \n with empty string may be less error prone

### DIFF
--- a/lib/processors/html/helpers/TemplateEngine.js
+++ b/lib/processors/html/helpers/TemplateEngine.js
@@ -14,7 +14,7 @@ module.exports = function(html, options) {
 		cursor = match.index + match[0].length;
 	}
 	add(html.substr(cursor, html.length - cursor));
-	code = (code + 'return r.join(""); }').replace(/[\r\t\n]/g, '');
+	code = (code + 'return r.join(""); }').replace(/[\r\t\n]/g, ' ');
 	try { result = new Function('obj', code).apply(options, [options]); }
 	catch(err) { console.error("'" + err.message + "'", " in \n\nCode:\n", code, "\n"); }
 	return result;


### PR DESCRIPTION
I'm using this snippet for creating SQL queries (I understand the security issues, and it's ok in my case).
For the SQL use case, concatenating multiple lines can generate invalid statements like `select *from mytable`
I can also imagine a case with html where this can lead to problems like `<inputtype="text">`
So it's probably better to assume that some kind of empty space is needed.